### PR TITLE
Fix mismatched variable names and declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,5 +158,5 @@ Then restart Claude Code.
 ---
 
 **License**: CC0 1.0 Universal - Public Domain Dedication
-**Maintainer**: rathremercurial.eth
+**Maintainer**: rathermercurial.eth
 **Community**: SuperBenefit

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Then restart Claude Code. The plugin will be automatically downloaded and enable
 
 ## What's Included
 
-### Astro Dev Plugin (v0.3.0)
+### Astro Dev Plugin (v0.3.1)
 
 A toolkit for Astro and Starlight development with orchestrator-based workflows.
 
@@ -227,8 +227,8 @@ For issues, questions, or contributions:
 
 ## Credits
 
-Created by rathremercurial.eth for the SuperBenefit community.
+Created by rathermercurial.eth for the SuperBenefit community.
 
-**Version**: 0.3.0
+**Version**: 0.3.1
 **Last Updated**: 2025-10-20
 **Repository**: https://github.com/superbenefit/sb-marketplace

--- a/astro-dev/.claude-plugin/plugin.json
+++ b/astro-dev/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "description": "Astro/Starlight development toolkit with orchestrator-based workflows and configurable validation",
   "version": "0.3.1",
   "author": {
-    "name": "rathremercurial.eth",
+    "name": "rathermercurial.eth",
     "email": "rathermercurial@protonmail.com",
     "url": "https://github.com/rathermercurial"
   },

--- a/astro-dev/CHANGELOG.md
+++ b/astro-dev/CHANGELOG.md
@@ -183,5 +183,5 @@ Internal development version with basic agent system and comprehensive knowledge
 ---
 
 **License**: CC0 1.0 Universal - Public Domain Dedication
-**Author**: rathremercurial.eth
+**Author**: rathermercurial.eth
 **Community**: SuperBenefit

--- a/astro-dev/README.md
+++ b/astro-dev/README.md
@@ -66,7 +66,7 @@ This plugin provides expert assistance for Astro and Starlight development throu
 
 ### Skills
 
-#### `astro-developer`
+#### `astro-coding`
 Expert implementation skill for all Astro/Starlight code:
 - Component development
 - Dynamic routing with getStaticPaths
@@ -76,14 +76,14 @@ Expert implementation skill for all Astro/Starlight code:
 
 **When it loads**: When implementing features, writing components, or fixing code.
 
-#### `astro-docs`
+#### `astro-knowledge`
 Documentation specialist for quick API verification:
 - API syntax lookup
 - Feature availability checks
 - Current best practices
 - Documentation search
 
-**When it loads**: When using `/docs-lookup` or needing API verification.
+**When it loads**: When using `/lookup` or needing API verification.
 
 ### Agents
 
@@ -122,10 +122,10 @@ Runs comprehensive code audit:
 
 Returns prioritized report with fixes.
 
-#### `/docs-lookup [api]`
+#### `/lookup [api]`
 Quick documentation lookup:
 ```bash
-/docs-lookup getCollection
+/lookup getCollection
 ```
 
 Returns syntax, examples, and documentation links.
@@ -208,7 +208,7 @@ Comprehensive reference materials organized by category:
 ```
 
 Claude will:
-1. Load astro-developer skill
+1. Load astro-coding skill
 2. Check project structure
 3. Review best practices
 4. Implement the feature
@@ -231,7 +231,7 @@ Claude will:
 ### API Verification
 
 ```bash
-/docs-lookup getStaticPaths
+/lookup getStaticPaths
 ```
 
 Returns:
@@ -297,10 +297,10 @@ astro-dev/
 ├── .claude-plugin/
 │   └── plugin.json              # Manifest
 ├── skills/
-│   ├── astro-developer/
+│   ├── astro-coding/
 │   │   ├── SKILL.md            # Skill definition
 │   │   └── references/         # Quick references
-│   └── astro-docs/
+│   └── astro-knowledge/
 │       ├── SKILL.md            # Skill definition
 │       └── references/         # Cached docs
 ├── agents/
@@ -309,7 +309,7 @@ astro-dev/
 ├── commands/
 │   ├── implement.md            # /implement command
 │   ├── audit.md                # /audit command
-│   └── docs-lookup.md          # /docs-lookup command
+│   └── lookup.md               # /lookup command
 ├── hooks/
 │   └── hooks.json              # Hook configuration
 ├── scripts/
@@ -342,12 +342,12 @@ astro-dev/
 ### Skills Not Triggering
 
 1. Skills load on-demand when relevant
-2. Use commands to explicitly trigger: `/implement`, `/docs-lookup`
+2. Use commands to explicitly trigger: `/implement`, `/lookup`
 3. Check skill names match plugin manifest
 
 ## Version
 
-Current version: 0.3.0
+Current version: 0.3.1
 
 See CHANGELOG.md for version history and updates.
 
@@ -359,7 +359,7 @@ This plugin is dedicated to the public domain. You can copy, modify, distribute 
 
 ## Author
 
-Created by rathremercurial.eth for the SuperBenefit community.
+Created by rathermercurial.eth for the SuperBenefit community.
 
 ## Contributing
 

--- a/astro-dev/agents/astro-architect.md
+++ b/astro-dev/agents/astro-architect.md
@@ -291,8 +291,8 @@ export async function getStaticPaths() {
 
 ## Collaboration
 
-- Works with **astro-developer** skill for implementation
-- Coordinates with **astro-docs** for API verification
+- Works with **astro-coding** skill for implementation
+- Coordinates with **astro-knowledge** for API verification
 - Provides specs for **astro-auditor** validation
 - Delivers comprehensive architecture documentation
 


### PR DESCRIPTION
- Fix author name typo: rathremercurial.eth → rathermercurial.eth
- Update skill names: astro-developer → astro-coding, astro-docs → astro-knowledge
- Update command names: /docs-lookup → /lookup
- Update version numbers: 0.3.0 → 0.3.1

This addresses all naming mismatches found in manifests, declarations, and documentation to ensure consistency across the repository.