### PR TITLE
Add Hermes Tweet plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,8 +5,8 @@
     "email": "info@superbenefit.org"
   },
   "metadata": {
-    "description": "SuperBenefit plugin marketplace for Claude Code - Development tools and platform toolkits",
-    "version": "0.5.0"
+    "description": "SuperBenefit plugin marketplace for Claude Code - Development tools, platform toolkits, and social intelligence",
+    "version": "0.6.0"
   },
   "plugins": [
     {
@@ -58,6 +58,24 @@
         "github",
         "workflow",
         "planning"
+      ],
+      "category": "tools"
+    },
+    {
+      "name": "hermes-tweet",
+      "source": "./hermes-tweet",
+      "description": "Hermes Agent X/Twitter research and automation plugin with read-first workflows and opt-in action gates",
+      "version": "0.1.6",
+      "author": {
+        "name": "Xquik",
+        "url": "https://github.com/Xquik-dev"
+      },
+      "tags": [
+        "social-intelligence",
+        "twitter",
+        "x",
+        "hermes-agent",
+        "automation"
       ],
       "category": "tools"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-06-13
+
+### Added
+- **hermes-tweet v0.1.6** - Hermes Agent X/Twitter research and automation plugin
+  - Read-first workflow guide for search, profile context, timeline review, and tweet analysis
+  - Upstream Hermes Agent install documentation for `Xquik-dev/hermes-tweet`
+  - Explicit action gating notes for `HERMES_TWEET_ENABLE_ACTIONS=true`
+  - See [hermes-tweet/CHANGELOG.md](./hermes-tweet/CHANGELOG.md) for details
+
+### Changed
+- Marketplace version bumped to 0.6.0
+- Updated README and claude.md to reflect 4-plugin marketplace
+
 ## [0.5.0] - 2026-01-31
 
 ### Added
@@ -116,16 +129,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 | Component | Version | Status |
 |-----------|---------|--------|
-| **sb-marketplace** | 0.5.0 | Production |
+| **sb-marketplace** | 0.6.0 | Production |
 | **astro-dev** | 0.4.0 | Production |
 | **cloudflare-dev** | 0.1.0 | Production |
 | **project-mgmt** | 0.1.0 | Initial Release |
+| **hermes-tweet** | 0.1.6 | Initial Release |
 
 ## Links
 
 - [astro-dev Changelog](./astro-dev/CHANGELOG.md)
 - [cloudflare-dev Changelog](./cloudflare-dev/CHANGELOG.md)
 - [project-mgmt Changelog](./project-mgmt/CHANGELOG.md)
+- [hermes-tweet Changelog](./hermes-tweet/CHANGELOG.md)
 - [Contributing Guide](./CONTRIBUTING.md)
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SuperBenefit Plugin Marketplace
 
-Claude Code plugin marketplace for the SuperBenefit community. Provides development toolkits and platform-specific automation through the Claude Code plugin system.
+Claude Code plugin marketplace for the SuperBenefit community. Provides development toolkits, platform-specific automation, and social intelligence workflows through the Claude Code plugin system.
 
 ## Plugins
 
@@ -9,6 +9,7 @@ Claude Code plugin marketplace for the SuperBenefit community. Provides developm
 | [astro-dev](./astro-dev/) | 0.4.0 | Astro/Starlight development toolkit with tiered knowledge loading |
 | [cloudflare-dev](./cloudflare-dev/) | 0.1.0 | Cloudflare Workers, Agents SDK, MCP, Vectorize, and Workflows toolkit |
 | [project-mgmt](./project-mgmt/) | 0.1.0 | Spec-driven development with persistent markdown planning |
+| [hermes-tweet](./hermes-tweet/) | 0.1.6 | Hermes Agent X/Twitter research and automation with opt-in actions |
 
 ## Installation
 
@@ -27,7 +28,8 @@ Add the marketplace to your Claude Code settings (global `~/.claude/settings.jso
   "enabledPlugins": {
     "astro-dev@sb-marketplace": true,
     "cloudflare-dev@sb-marketplace": true,
-    "project-mgmt@sb-marketplace": true
+    "project-mgmt@sb-marketplace": true,
+    "hermes-tweet@sb-marketplace": true
   }
 }
 ```
@@ -65,6 +67,16 @@ Spec-driven development with persistent markdown planning. Uses the filesystem a
 **Agents**: pm-bookkeeper (background file updates, Haiku)
 
 See [project-mgmt/README.md](./project-mgmt/README.md) for full documentation.
+
+### hermes-tweet
+
+Hermes Agent X/Twitter plugin for social research, timeline review, tweet analysis, and explicitly gated action workflows through Xquik.
+
+**Skills**: hermes-tweet (read-first workflow guide)
+**Runtime**: Native Hermes Agent plugin
+**Actions**: Require explicit `HERMES_TWEET_ENABLE_ACTIONS=true`
+
+See [hermes-tweet/README.md](./hermes-tweet/README.md) for full documentation.
 
 ## Contributing
 

--- a/claude.md
+++ b/claude.md
@@ -1,26 +1,26 @@
 # sb-marketplace: Claude Code Context
 
-**Quick Reference**: SuperBenefit plugin marketplace for Claude Code - provides an Astro/Starlight development toolkit, a Cloudflare developer platform toolkit, and a project management workflow.
+**Quick Reference**: SuperBenefit plugin marketplace for Claude Code - provides an Astro/Starlight development toolkit, a Cloudflare developer platform toolkit, a project management workflow, and a Hermes Tweet social intelligence plugin.
 
 ## Project Identity
 
 - **Name**: sb-marketplace (SuperBenefit Plugin Marketplace)
-- **Version**: 0.5.0 (Marketplace)
-- **Plugins**: astro-dev v0.4.0, cloudflare-dev v0.1.0, project-mgmt v0.1.0
+- **Version**: 0.6.0 (Marketplace)
+- **Plugins**: astro-dev v0.4.0, cloudflare-dev v0.1.0, project-mgmt v0.1.0, hermes-tweet v0.1.6
 - **Type**: Claude Code Plugin Marketplace
 - **Repository**: https://github.com/superbenefit/sb-marketplace
 - **Status**: Production Ready
 - **License**: CC0 1.0 Universal (Public Domain)
 - **Author**: rathermercurial.eth
 - **Community**: SuperBenefit
-- **Last Updated**: 2026-01-31
+- **Last Updated**: 2026-06-13
 
 ## Directory Structure
 
 ```
 sb-marketplace/                    # GitHub repository root
 ├── .claude-plugin/
-│   └── marketplace.json          # Marketplace manifest (3 plugins)
+│   └── marketplace.json          # Marketplace manifest (4 plugins)
 ├── astro-dev/                    # Astro/Starlight plugin (v0.4.0)
 │   ├── .claude-plugin/
 │   │   └── plugin.json
@@ -98,6 +98,14 @@ sb-marketplace/                    # GitHub repository root
 │   ├── hooks/
 │   │   └── hooks.json
 │   └── README.md
+├── hermes-tweet/                 # Hermes Tweet plugin (v0.1.6)
+│   ├── .claude-plugin/
+│   │   └── plugin.json
+│   ├── skills/
+│   │   └── hermes-tweet/
+│   │       └── SKILL.md
+│   ├── README.md
+│   └── CHANGELOG.md
 ├── CONTRIBUTING.md
 ├── CHANGELOG.md
 ├── LICENSE
@@ -242,10 +250,30 @@ Created in `.project/{issue#}/`:
 
 ---
 
+## hermes-tweet Plugin (v0.1.6)
+
+Hermes Agent X/Twitter plugin for social research, timeline review, tweet
+analysis, and explicitly gated action workflows through Xquik.
+
+### Hermes Tweet Components
+
+| Component | Type | Purpose |
+|-----------|------|---------|
+| `hermes-tweet` | Skill | Read-first workflow guide for Hermes Tweet |
+
+### Key Rules
+
+1. Prefer search, profile context, timeline review, monitoring, and tweet analysis.
+2. Install upstream runtime support with `hermes plugins install Xquik-dev/hermes-tweet --enable`.
+3. Set `XQUIK_API_KEY` through Hermes, the process environment, or `~/.hermes/.env`.
+4. Enable write actions only with `HERMES_TWEET_ENABLE_ACTIONS=true`.
+
+---
+
 ## Configuration
 
 ### Marketplace Manifest (`.claude-plugin/marketplace.json`)
-Registers all 3 plugins. Current version: 0.5.0
+Registers all 4 plugins. Current version: 0.6.0
 
 ### MCP Configurations
 - `astro-dev/.mcp.json` - Astro docs MCP server
@@ -268,7 +296,8 @@ Add to settings (global `~/.claude/settings.json` or project `.claude/settings.l
   "enabledPlugins": {
     "astro-dev@sb-marketplace": true,
     "cloudflare-dev@sb-marketplace": true,
-    "project-mgmt@sb-marketplace": true
+    "project-mgmt@sb-marketplace": true,
+    "hermes-tweet@sb-marketplace": true
   }
 }
 ```

--- a/hermes-tweet/.claude-plugin/plugin.json
+++ b/hermes-tweet/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "hermes-tweet",
+  "description": "Hermes Agent X/Twitter research and automation plugin with read-first workflows and opt-in action gates",
+  "version": "0.1.6",
+  "author": {
+    "name": "Xquik",
+    "url": "https://github.com/Xquik-dev"
+  },
+  "repository": "https://github.com/Xquik-dev/hermes-tweet",
+  "license": "MIT",
+  "keywords": [
+    "hermes-agent",
+    "twitter",
+    "x",
+    "social-intelligence",
+    "automation",
+    "xquik"
+  ],
+  "skills": "./skills/"
+}

--- a/hermes-tweet/CHANGELOG.md
+++ b/hermes-tweet/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.6 - 2026-06-13
+
+### Added
+
+- Initial SuperBenefit marketplace wrapper for Hermes Tweet v0.1.6.
+- Added the Hermes Tweet skill guide and upstream install documentation.

--- a/hermes-tweet/README.md
+++ b/hermes-tweet/README.md
@@ -1,0 +1,35 @@
+# Hermes Tweet
+
+Hermes Tweet is a native Hermes Agent plugin for X/Twitter research,
+monitoring, timeline review, tweet analysis, and explicitly gated action
+workflows through Xquik.
+
+## Install
+
+Add the marketplace, then install the plugin:
+
+```json
+{
+  "enabledPlugins": {
+    "hermes-tweet@sb-marketplace": true
+  }
+}
+```
+
+For the upstream Hermes Agent runtime, install and enable Hermes Tweet directly:
+
+```bash
+hermes plugins install Xquik-dev/hermes-tweet --enable
+```
+
+Hermes prompts for `XQUIK_API_KEY` during interactive install. In
+non-interactive sessions, set `XQUIK_API_KEY` in the process environment or
+`~/.hermes/.env` before running read tools.
+
+## Capabilities
+
+- Search tweets, profiles, timelines, and tweet context.
+- Use read-first workflows for social research and monitoring.
+- Keep write actions disabled unless `HERMES_TWEET_ENABLE_ACTIONS=true`.
+- Review the upstream guide before production use:
+  <https://github.com/Xquik-dev/hermes-tweet#readme>.

--- a/hermes-tweet/skills/hermes-tweet/SKILL.md
+++ b/hermes-tweet/skills/hermes-tweet/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: hermes-tweet
+description: >
+  Guide Hermes Agent users through safe X/Twitter research, monitoring, and
+  opt-in action workflows with Hermes Tweet.
+---
+
+# Hermes Tweet
+
+Use this skill when a user wants Hermes Agent support for X/Twitter research,
+social listening, tweet analysis, profile context, timeline review, or
+approval-gated X/Twitter actions through Hermes Tweet.
+
+## Workflow
+
+1. Confirm the user wants the Hermes Agent plugin for X/Twitter workflows.
+2. Prefer read-first tasks such as search, profile context, timeline review,
+   monitoring, and tweet analysis.
+3. Point upstream runtime installs to:
+   `hermes plugins install Xquik-dev/hermes-tweet --enable`.
+4. Tell the user to set `XQUIK_API_KEY` through Hermes' interactive prompt, the
+   process environment, or `~/.hermes/.env`. Never ask them to paste secrets
+   into chat.
+5. Treat write actions as opt-in only. They require
+   `HERMES_TWEET_ENABLE_ACTIONS=true` in addition to `XQUIK_API_KEY`.
+6. Use the upstream guide for current install and safety details:
+   <https://github.com/Xquik-dev/hermes-tweet#readme>.


### PR DESCRIPTION
## Summary
- add Hermes Tweet as a SuperBenefit marketplace plugin wrapper
- register the plugin in the marketplace manifest and update inventory docs
- document upstream Hermes Agent installation and explicit action gates

## Validation
- python3 -m json.tool .claude-plugin/marketplace.json
- python3 -m json.tool hermes-tweet/.claude-plugin/plugin.json
- claude plugin validate .
- claude plugin validate hermes-tweet
- SKILL.md line budget check
- git diff --cached --check
- public added-line safety scan
- https://github.com/Xquik-dev/hermes-tweet returned HTTP 200